### PR TITLE
Fix min target for black and the PyPI Changelog URL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.black]
 line-length = 79
-target-version = ['py37']
+target-version = ['py310']
 
 [tool.ruff]
 # https://beta.ruff.rs/docs/configuration/

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ classifiers =
     Typing :: Typed
 keywords = Django
 project_urls =
-    Changelog = https://github.com/marksweb/django-nf3/blob/main/CHANGELOG.rst
+    Changelog = https://github.com/marksweb/django-nh3/blob/main/CHANGELOG.rst
     Mastodon = https://fosstodon.org/@markwalker
     Twitter = https://twitter.com/markwalker_
 


### PR DESCRIPTION
Noticed a couple of minor things while clicking through form PyPI (and nosing around)

Recent versions of black can infer the minimum Python version from `pyproject.toml`

Would you be up for a PR changing to new style project metadata (i.e. in `pyproject.toml` as per [PEP 621](https://peps.python.org/pep-0621/)) ?