### PR TITLE
Drop ruff from GitHub Actions as it is covered by pre-commit.ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,20 +78,3 @@ jobs:
         with:
           name: html-report
           path: htmlcov
-
-  ruff:
-    name: ruff
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - run: |
-          python -m pip install --upgrade pip
-          pip install ruff
-      - name: Run Ruff
-        working-directory: ./src
-        run: ruff django_nh3


### PR DESCRIPTION
IMHO there is no need to do additional processing if you don't have to