### PR TITLE
Re-add Ruff to GitHub Actions

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,18 @@
+name: Ruff
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - run: python -Im pip install ruff
+
+    - name: Run ruff
+      working-directory: ./src
+      run: ruff --output-format=github django_nh3

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - run: python -Im pip install ruff
+    - run: python -Im pip install --user ruff
 
     - name: Run ruff
       working-directory: ./src

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
   hooks:
   - id: pyupgrade
     args: [--py310-plus]
-- repo: https://github.com/psf/black
+- repo: https://github.com/psf/black-pre-commit-mirror
   rev: 23.12.1
   hooks:
   - id: black


### PR DESCRIPTION
with annotations as per discussion in #21

also changes pre-commit config to use https://github.com/psf/black-pre-commit-mirror as per https://github.com/psf/black/blob/main/CHANGES.md#integrations-5 - which should be faster
