### PR TITLE
Fix mutable default argument values

### DIFF
--- a/src/django_nh3/forms.py
+++ b/src/django_nh3/forms.py
@@ -15,17 +15,23 @@ class Nh3Field(forms.CharField):
 
     def __init__(
         self,
-        attributes: dict[str, set[str]] = {},
+        attributes: dict[str, set[str]] | None = None,
         attribute_filter: Callable[[str, str, str], str] | None = None,
-        clean_content_tags: set[str] = set(),
+        clean_content_tags: set[str] | None = None,
         empty_value: Any | None = "",
         link_rel: str = "",
         strip_comments: bool = False,
-        tags: set[str] = set(),
+        tags: set[str] | None = None,
         *args: Any,
         **kwargs: dict[Any, Any],
     ):
         super().__init__(*args, **kwargs)
+        if attributes is None:
+            attributes = {}
+        if clean_content_tags is None:
+            clean_content_tags = set()
+        if tags is None:
+            tags = set()
 
         self.empty_value = empty_value
         self.nh3_options = {

--- a/src/django_nh3/models.py
+++ b/src/django_nh3/models.py
@@ -16,16 +16,22 @@ from . import forms
 class Nh3Field(models.TextField):
     def __init__(
         self,
-        attributes: dict[str, set[str]] = {},
+        attributes: dict[str, set[str]] | None = None,
         attribute_filter: Callable[[str, str, str], str] | None = None,
-        clean_content_tags: set[str] = set(),
+        clean_content_tags: set[str] | None = None,
         link_rel: str = "",
         strip_comments: bool = False,
-        tags: set[str] = set(),
+        tags: set[str] | None = None,
         *args: Any,
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
+        if attributes is None:
+            attributes = {}
+        if clean_content_tags is None:
+            clean_content_tags = set()
+        if tags is None:
+            tags = set()
 
         self.nh3_options = {
             "attributes": attributes,


### PR DESCRIPTION
Hey there, I noticed some function arguments using mutable types (sets, dicts) as default values.
While this doesn't appear to cause issues right now, it could lead to unexpected behavior if any future code modifies these default objects.
I thought to change the defaults to `None` and initialize them in the `__init__`s if needed. What do you think?