### PR TITLE
Nh3charfield and nh3textfield

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,6 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
-.idea/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+.idea/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ classifiers = [
 dependencies = [
   "django>=3.2",
   "nh3",
+  "typing-extensions",
 ]
 
 urls.Changelog = "https://github.com/marksweb/django-nh3/blob/main/CHANGELOG.rst"

--- a/src/django_nh3/models.py
+++ b/src/django_nh3/models.py
@@ -81,10 +81,10 @@ class Nh3Text(models.TextField):
 
 
 def Nh3Field(*args: Any, **kwargs: Any) -> Nh3Text:
-    warnings.warn(
-        "Nh3Field is deprecated, use Nh3Text instead",
-        DeprecationWarning,
-        stacklevel=2,
+    warnings.filterwarnings(
+        action="default",
+        message="Nh3Field is deprecated, use Nh3Text instead",
+        category=DeprecationWarning,
     )
     return Nh3Text(*args, **kwargs)
 

--- a/src/django_nh3/models.py
+++ b/src/django_nh3/models.py
@@ -1,8 +1,7 @@
-from __future__ import annotations
-
 import warnings
 from collections.abc import Callable
 from typing import Any
+from typing_extensions import deprecated
 
 import nh3
 from django.db import models
@@ -14,7 +13,7 @@ from django.utils.safestring import mark_safe
 from . import forms
 
 
-class Nh3Text(models.TextField):
+class Nh3FieldMixin:
     def __init__(
         self,
         attributes: dict[str, set[str]] = {},
@@ -80,76 +79,24 @@ class Nh3Text(models.TextField):
         return mark_safe(value)
 
 
-def Nh3Field(*args: Any, **kwargs: Any) -> Nh3Text:
-    warnings.filterwarnings(
-        action="default",
-        message="Nh3Field is deprecated, use Nh3Text instead",
-        category=FutureWarning,
-    )
-    return Nh3Text(*args, **kwargs)
+class Nh3TextField(Nh3FieldMixin, models.TextField):
+    pass
 
 
-class Nh3Char(models.CharField):
-    def __init__(
-        self,
-        attributes: dict[str, set[str]] = {},
-        attribute_filter: Callable[[str, str, str], str] | None = None,
-        clean_content_tags: set[str] = set(),
-        link_rel: str = "",
-        strip_comments: bool = False,
-        tags: set[str] = set(),
-        *args: Any,
-        **kwargs: Any,
-    ) -> None:
+class Nh3CharField(Nh3FieldMixin, models.CharField):
+    pass
+
+
+@deprecated("Use Nh3TextField instead")
+class Nh3Field(Nh3FieldMixin, models.TextField):
+    """
+    .. deprecated:: 0.2.0
+    Use :class:`Nh3TextField` instead.
+    """
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "Nh3Field is deprecated and will be removed in a future version. Use Nh3TextField instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__(*args, **kwargs)
-
-        self.nh3_options = {
-            "attributes": attributes,
-            "attribute_filter": attribute_filter,
-            "clean_content_tags": clean_content_tags,
-            "link_rel": link_rel,
-            "strip_comments": strip_comments,
-            "tags": tags,
-        }
-
-    def formfield(
-        self, form_class: FormField = forms.Nh3Field, **kwargs: Any
-    ) -> FormField:
-        """Makes the field for a ModelForm"""
-
-        # If field doesn't have any choices add kwargs expected by Nh3Field.
-        if not self.choices:
-            kwargs.update(
-                {
-                    "max_length": self.max_length,
-                    "attributes": self.nh3_options.get("attributes"),
-                    "attribute_filter": self.nh3_options.get("attribute_filter"),
-                    "clean_content_tags": self.nh3_options.get("clean_content_tags"),
-                    "link_rel": self.nh3_options.get("link_rel"),
-                    "strip_comments": self.nh3_options.get("strip_comments"),
-                    "tags": self.nh3_options.get("tags"),
-                    "required": not self.blank,
-                }
-            )
-
-        return super().formfield(form_class=form_class, **kwargs)
-
-    def pre_save(self, model_instance: Model, add: bool) -> Any:
-        data = getattr(model_instance, self.attname)
-        if data is None:
-            return data
-        clean_value = nh3.clean(data, **self.nh3_options) if data else ""
-        setattr(model_instance, self.attname, mark_safe(clean_value))
-        return clean_value
-
-    def from_db_value(
-        self,
-        value: Any,
-        expression: Expression,
-        connection: BaseDatabaseWrapper,
-    ) -> Any:
-        if value is None:
-            return value
-        # Values are sanitised before saving, so any value returned from the DB
-        # is safe to render unescaped.
-        return mark_safe(value)

--- a/src/django_nh3/models.py
+++ b/src/django_nh3/models.py
@@ -84,7 +84,7 @@ def Nh3Field(*args: Any, **kwargs: Any) -> Nh3Text:
     warnings.filterwarnings(
         action="default",
         message="Nh3Field is deprecated, use Nh3Text instead",
-        category=DeprecationWarning,
+        category=FutureWarning,
     )
     return Nh3Text(*args, **kwargs)
 

--- a/src/django_nh3/models.py
+++ b/src/django_nh3/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable
 from typing import Any
 
@@ -13,7 +14,82 @@ from django.utils.safestring import mark_safe
 from . import forms
 
 
-class Nh3Field(models.TextField):
+class Nh3Text(models.TextField):
+    def __init__(
+        self,
+        attributes: dict[str, set[str]] = {},
+        attribute_filter: Callable[[str, str, str], str] | None = None,
+        clean_content_tags: set[str] = set(),
+        link_rel: str = "",
+        strip_comments: bool = False,
+        tags: set[str] = set(),
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+
+        self.nh3_options = {
+            "attributes": attributes,
+            "attribute_filter": attribute_filter,
+            "clean_content_tags": clean_content_tags,
+            "link_rel": link_rel,
+            "strip_comments": strip_comments,
+            "tags": tags,
+        }
+
+    def formfield(
+        self, form_class: FormField = forms.Nh3Field, **kwargs: Any
+    ) -> FormField:
+        """Makes the field for a ModelForm"""
+
+        # If field doesn't have any choices add kwargs expected by Nh3Field.
+        if not self.choices:
+            kwargs.update(
+                {
+                    "max_length": self.max_length,
+                    "attributes": self.nh3_options.get("attributes"),
+                    "attribute_filter": self.nh3_options.get("attribute_filter"),
+                    "clean_content_tags": self.nh3_options.get("clean_content_tags"),
+                    "link_rel": self.nh3_options.get("link_rel"),
+                    "strip_comments": self.nh3_options.get("strip_comments"),
+                    "tags": self.nh3_options.get("tags"),
+                    "required": not self.blank,
+                }
+            )
+
+        return super().formfield(form_class=form_class, **kwargs)
+
+    def pre_save(self, model_instance: Model, add: bool) -> Any:
+        data = getattr(model_instance, self.attname)
+        if data is None:
+            return data
+        clean_value = nh3.clean(data, **self.nh3_options) if data else ""
+        setattr(model_instance, self.attname, mark_safe(clean_value))
+        return clean_value
+
+    def from_db_value(
+        self,
+        value: Any,
+        expression: Expression,
+        connection: BaseDatabaseWrapper,
+    ) -> Any:
+        if value is None:
+            return value
+        # Values are sanitised before saving, so any value returned from the DB
+        # is safe to render unescaped.
+        return mark_safe(value)
+
+
+def Nh3Field(*args: Any, **kwargs: Any) -> Nh3Text:
+    warnings.warn(
+        "Nh3Field is deprecated, use Nh3Text instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return Nh3Text(*args, **kwargs)
+
+
+class Nh3Char(models.CharField):
     def __init__(
         self,
         attributes: dict[str, set[str]] = {},

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -1,0 +1,41 @@
+from django.forms import ModelForm
+
+from .models import (
+    Nh3CharFieldContent,
+    Nh3CharFieldNullableContent,
+    Nh3TextFieldContent,
+    Nh3TextFieldNullableContent,
+)
+
+
+
+class Nh3CharFieldContentModelForm(ModelForm):
+    """NH3 test model form"""
+
+    class Meta:
+        model = Nh3CharFieldContent
+        fields = ["content"]
+
+
+class Nh3CharFieldNullableContentModelForm(ModelForm):
+    """NH3 test model form"""
+
+    class Meta:
+        model = Nh3CharFieldNullableContent
+        fields = ["choice"]
+
+
+class Nh3TextFieldContentModelForm(ModelForm):
+    """NH3 test model form"""
+
+    class Meta:
+        model = Nh3TextFieldContent
+        fields = ["content"]
+
+
+class Nh3TextFieldNullableContentModelForm(ModelForm):
+    """NH3 test model form"""
+
+    class Meta:
+        model = Nh3TextFieldNullableContent
+        fields = ["choice"]

--- a/tests/migrations/0001_initial.py
+++ b/tests/migrations/0001_initial.py
@@ -11,7 +11,7 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.CreateModel(
-            name="Nh3Content",
+            name="Nh3CharFieldContent",
             fields=[
                 (
                     "id",
@@ -22,16 +22,36 @@ class Migration(migrations.Migration):
                         verbose_name="ID",
                     ),
                 ),
-                ("content", django_nh3.models.Nh3Field()),
-                ("blank_field", django_nh3.models.Nh3Field(blank=True)),
+                ("content", django_nh3.models.Nh3CharField(max_length=1000)),
+                ("blank_field", django_nh3.models.Nh3CharField(blank=True, max_length=1000)),
                 (
                     "null_field",
-                    django_nh3.models.Nh3Field(blank=True, null=True),
+                    django_nh3.models.Nh3CharField(blank=True, null=True, max_length=1000),
                 ),
             ],
         ),
         migrations.CreateModel(
-            name="Nh3NullableContent",
+            name="Nh3TextFieldContent",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("content", django_nh3.models.Nh3TextField(max_length=1000)),
+                ("blank_field", django_nh3.models.Nh3TextField(blank=True, max_length=1000)),
+                (
+                    "null_field",
+                    django_nh3.models.Nh3TextField(blank=True, null=True, max_length=1000),
+                ),
+            ],
+        ),
+        migrations.CreateModel(
+            name="Nh3CharFieldNullableContent",
             fields=[
                 (
                     "id",
@@ -44,11 +64,36 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "choice",
-                    django_nh3.models.Nh3Field(
-                        choices=[("f", "first choice"), ("s", "second choice")]
+                    django_nh3.models.Nh3CharField(
+                        blank=True,
+                        choices=[("f", "first choice"), ("s", "second choice")],
+                        max_length=1000,
                     ),
                 ),
-                ("content", django_nh3.models.Nh3Field(blank=True, null=True)),
+                ("content", django_nh3.models.Nh3CharField(blank=True, null=True, max_length=1000)),
+            ],
+        ),
+        migrations.CreateModel(
+            name="Nh3TextFieldNullableContent",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "choice",
+                    django_nh3.models.Nh3TextField(
+                        blank=True,
+                        choices=[("f", "first choice"), ("s", "second choice")],
+                        max_length=1000,
+                    ),
+                ),
+                ("content", django_nh3.models.Nh3TextField(blank=True, null=True, max_length=1000)),
             ],
         ),
     ]

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,0 +1,41 @@
+from django.db import models
+
+from django_nh3.models import Nh3CharField, Nh3TextField
+
+
+class Nh3CharFieldContent(models.Model):
+    """NH3 test model"""
+
+    content = Nh3CharField(
+        strip_comments=True,
+        max_length=1000,
+    )
+    blank_field = Nh3CharField(blank=True, max_length=1000)
+    null_field = Nh3CharField(blank=True, null=True, max_length=1000)
+
+
+class Nh3CharFieldNullableContent(models.Model):
+    """NH3 test model"""
+
+    CHOICES = (("f", "first choice"), ("s", "second choice"))
+    choice = Nh3CharField(choices=CHOICES, blank=True, max_length=1000)
+    content = Nh3CharField(blank=True, null=True, max_length=1000)
+
+
+class Nh3TextFieldContent(models.Model):
+    """NH3 test model"""
+
+    content = Nh3TextField(
+        strip_comments=True,
+        max_length=1000,
+    )
+    blank_field = Nh3TextField(blank=True, max_length=1000)
+    null_field = Nh3TextField(blank=True, null=True, max_length=1000)
+
+
+class Nh3TextFieldNullableContent(models.Model):
+    """NH3 test model"""
+
+    CHOICES = (("f", "first choice"), ("s", "second choice"))
+    choice = Nh3TextField(choices=CHOICES, blank=True, max_length=1000)
+    content = Nh3TextField(blank=True, null=True, max_length=1000)

--- a/tests/test_models_charfield.py
+++ b/tests/test_models_charfield.py
@@ -3,17 +3,17 @@ from django.forms import ModelForm
 from django.test import TestCase
 from django.utils.safestring import SafeString
 
-from django_nh3.models import Nh3Field
+from django_nh3.models import Nh3Char
 
 
 class Nh3Content(models.Model):
     """NH3 test model"""
 
-    content = Nh3Field(
+    content = Nh3Char(
         strip_comments=True,
     )
-    blank_field = Nh3Field(blank=True)
-    null_field = Nh3Field(blank=True, null=True)
+    blank_field = Nh3Char(blank=True)
+    null_field = Nh3Char(blank=True, null=True)
 
 
 class Nh3ContentModelForm(ModelForm):
@@ -28,8 +28,8 @@ class Nh3NullableContent(models.Model):
     """NH3 test model"""
 
     CHOICES = (("f", "first choice"), ("s", "second choice"))
-    choice = Nh3Field(choices=CHOICES, blank=True)
-    content = Nh3Field(blank=True, null=True)
+    choice = Nh3Char(choices=CHOICES, blank=True)
+    content = Nh3Char(blank=True, null=True)
 
 
 class Nh3NullableContentModelForm(ModelForm):

--- a/tests/test_models_charfield.py
+++ b/tests/test_models_charfield.py
@@ -1,46 +1,11 @@
-from django.db import models
-from django.forms import ModelForm
 from django.test import TestCase
 from django.utils.safestring import SafeString
 
-from django_nh3.models import Nh3Char
+from .forms import Nh3CharFieldContentModelForm, Nh3CharFieldNullableContentModelForm
+from .models import Nh3CharFieldContent, Nh3CharFieldNullableContent
 
 
-class Nh3Content(models.Model):
-    """NH3 test model"""
-
-    content = Nh3Char(
-        strip_comments=True,
-    )
-    blank_field = Nh3Char(blank=True)
-    null_field = Nh3Char(blank=True, null=True)
-
-
-class Nh3ContentModelForm(ModelForm):
-    """NH3 test model form"""
-
-    class Meta:
-        model = Nh3Content
-        fields = ["content"]
-
-
-class Nh3NullableContent(models.Model):
-    """NH3 test model"""
-
-    CHOICES = (("f", "first choice"), ("s", "second choice"))
-    choice = Nh3Char(choices=CHOICES, blank=True)
-    content = Nh3Char(blank=True, null=True)
-
-
-class Nh3NullableContentModelForm(ModelForm):
-    """NH3 test model form"""
-
-    class Meta:
-        model = Nh3NullableContent
-        fields = ["choice"]
-
-
-class TestNh3ModelField(TestCase):
+class TestNh3ModelCharField(TestCase):
     """Test model field"""
 
     def test_cleaning(self):
@@ -57,32 +22,32 @@ class TestNh3ModelField(TestCase):
         }
 
         for key, value in test_data.items():
-            obj = Nh3Content.objects.create(content=value)
+            obj = Nh3CharFieldContent.objects.create(content=value)
             self.assertEqual(obj.content, expected_values[key])
 
     def test_retrieved_values_are_template_safe(self):
-        obj = Nh3Content.objects.create(content="some content")
+        obj = Nh3CharFieldContent.objects.create(content="some content")
         obj.refresh_from_db()
         self.assertIsInstance(obj.content, SafeString)
-        obj = Nh3Content.objects.create(content="")
+        obj = Nh3CharFieldContent.objects.create(content="")
         obj.refresh_from_db()
         self.assertIsInstance(obj.content, SafeString)
 
     def test_saved_values_are_template_safe(self):
-        obj = Nh3Content(content="some content")
+        obj = Nh3CharFieldContent(content="some content")
         obj.save()
         self.assertIsInstance(obj.content, SafeString)
-        obj = Nh3Content(content="")
+        obj = Nh3CharFieldContent(content="")
         obj.save()
         self.assertIsInstance(obj.content, SafeString)
 
     def test_saved_none_values_are_none(self):
-        obj = Nh3Content(null_field=None)
+        obj = Nh3CharFieldContent(null_field=None)
         obj.save()
         self.assertIsNone(obj.null_field)
 
 
-class TestNh3NullableModelField(TestCase):
+class TestNh3CharFieldNullableModelField(TestCase):
     """Test model field"""
 
     def test_cleaning(self):
@@ -101,11 +66,11 @@ class TestNh3NullableModelField(TestCase):
         }
 
         for key, value in test_data.items():
-            obj = Nh3NullableContent.objects.create(content=value)
+            obj = Nh3CharFieldNullableContent.objects.create(content=value)
             self.assertEqual(obj.content, expected_values[key])
 
 
-class TestNh3ModelFormField(TestCase):
+class TestNh3CharFieldModelFormField(TestCase):
     """Test model form field"""
 
     def test_cleaning(self):
@@ -122,7 +87,7 @@ class TestNh3ModelFormField(TestCase):
         }
 
         for key, value in test_data.items():
-            form = Nh3ContentModelForm(data={"content": value})
+            form = Nh3CharFieldContentModelForm(data={"content": value})
             self.assertTrue(form.is_valid())
             obj = form.save()
             self.assertEqual(obj.content, expected_values[key])
@@ -131,17 +96,17 @@ class TestNh3ModelFormField(TestCase):
         """Content field strips comments so ensure they aren't allowed"""
 
         self.assertFalse(
-            Nh3ContentModelForm(
+            Nh3CharFieldContentModelForm(
                 data={"content": "<!-- this is a comment -->"}
             ).is_valid()
         )
 
     def test_field_choices(self):
         """Content field strips comments so ensure they aren't allowed"""
-        test_data = dict(Nh3NullableContent.CHOICES)
+        test_data = dict(Nh3CharFieldNullableContent.CHOICES)
 
         for key, value in test_data.items():
-            form = Nh3NullableContentModelForm(data={"choice": key})
+            form = Nh3CharFieldNullableContentModelForm(data={"choice": key})
             self.assertTrue(form.is_valid())
             obj = form.save()
             self.assertEqual(obj.get_choice_display(), value)

--- a/tests/test_models_textfield.py
+++ b/tests/test_models_textfield.py
@@ -1,0 +1,147 @@
+from django.db import models
+from django.forms import ModelForm
+from django.test import TestCase
+from django.utils.safestring import SafeString
+
+from django_nh3.models import Nh3Text
+
+
+class Nh3Content(models.Model):
+    """NH3 test model"""
+
+    content = Nh3Text(
+        strip_comments=True,
+    )
+    blank_field = Nh3Text(blank=True)
+    null_field = Nh3Text(blank=True, null=True)
+
+
+class Nh3ContentModelForm(ModelForm):
+    """NH3 test model form"""
+
+    class Meta:
+        model = Nh3Content
+        fields = ["content"]
+
+
+class Nh3NullableContent(models.Model):
+    """NH3 test model"""
+
+    CHOICES = (("f", "first choice"), ("s", "second choice"))
+    choice = Nh3Text(choices=CHOICES, blank=True)
+    content = Nh3Text(blank=True, null=True)
+
+
+class Nh3NullableContentModelForm(ModelForm):
+    """NH3 test model form"""
+
+    class Meta:
+        model = Nh3NullableContent
+        fields = ["choice"]
+
+
+class TestNh3ModelField(TestCase):
+    """Test model field"""
+
+    def test_cleaning(self):
+        """Test values are sanitized"""
+        test_data = {
+            "html_data": "<h1>Heading</h1>",
+            "no_html": "Heading",
+            "html_comment": "<!-- this is a comment -->",
+        }
+        expected_values = {
+            "html_data": "Heading",
+            "no_html": "Heading",
+            "html_comment": "",
+        }
+
+        for key, value in test_data.items():
+            obj = Nh3Content.objects.create(content=value)
+            self.assertEqual(obj.content, expected_values[key])
+
+    def test_retrieved_values_are_template_safe(self):
+        obj = Nh3Content.objects.create(content="some content")
+        obj.refresh_from_db()
+        self.assertIsInstance(obj.content, SafeString)
+        obj = Nh3Content.objects.create(content="")
+        obj.refresh_from_db()
+        self.assertIsInstance(obj.content, SafeString)
+
+    def test_saved_values_are_template_safe(self):
+        obj = Nh3Content(content="some content")
+        obj.save()
+        self.assertIsInstance(obj.content, SafeString)
+        obj = Nh3Content(content="")
+        obj.save()
+        self.assertIsInstance(obj.content, SafeString)
+
+    def test_saved_none_values_are_none(self):
+        obj = Nh3Content(null_field=None)
+        obj.save()
+        self.assertIsNone(obj.null_field)
+
+
+class TestNh3NullableModelField(TestCase):
+    """Test model field"""
+
+    def test_cleaning(self):
+        """Test values are sanitized"""
+        test_data = {
+            "none": None,
+            "empty": "",
+            "whitespaces": "   ",
+            "linebreak": "\n",
+        }
+        expected_values = {
+            "none": None,
+            "empty": "",
+            "whitespaces": "   ",
+            "linebreak": "\n",
+        }
+
+        for key, value in test_data.items():
+            obj = Nh3NullableContent.objects.create(content=value)
+            self.assertEqual(obj.content, expected_values[key])
+
+
+class TestNh3ModelFormField(TestCase):
+    """Test model form field"""
+
+    def test_cleaning(self):
+        """Test values are sanitized"""
+        test_data = {
+            "html_data": "<h1>Heading</h1>",
+            "no_html": "Heading",
+            "spacing": " Heading ",
+        }
+        expected_values = {
+            "html_data": "Heading",
+            "no_html": "Heading",
+            "spacing": "Heading",
+        }
+
+        for key, value in test_data.items():
+            form = Nh3ContentModelForm(data={"content": value})
+            self.assertTrue(form.is_valid())
+            obj = form.save()
+            self.assertEqual(obj.content, expected_values[key])
+
+    def test_stripped_comments(self):
+        """Content field strips comments so ensure they aren't allowed"""
+
+        self.assertFalse(
+            Nh3ContentModelForm(
+                data={"content": "<!-- this is a comment -->"}
+            ).is_valid()
+        )
+
+    def test_field_choices(self):
+        """Content field strips comments so ensure they aren't allowed"""
+        test_data = dict(Nh3NullableContent.CHOICES)
+
+        for key, value in test_data.items():
+            form = Nh3NullableContentModelForm(data={"choice": key})
+            self.assertTrue(form.is_valid())
+            obj = form.save()
+            self.assertEqual(obj.get_choice_display(), value)

--- a/tests/test_models_textfield.py
+++ b/tests/test_models_textfield.py
@@ -3,44 +3,11 @@ from django.forms import ModelForm
 from django.test import TestCase
 from django.utils.safestring import SafeString
 
-from django_nh3.models import Nh3Text
+from .forms import Nh3TextFieldContentModelForm, Nh3TextFieldNullableContentModelForm
+from .models import Nh3TextFieldContent, Nh3TextFieldNullableContent
 
 
-class Nh3Content(models.Model):
-    """NH3 test model"""
-
-    content = Nh3Text(
-        strip_comments=True,
-    )
-    blank_field = Nh3Text(blank=True)
-    null_field = Nh3Text(blank=True, null=True)
-
-
-class Nh3ContentModelForm(ModelForm):
-    """NH3 test model form"""
-
-    class Meta:
-        model = Nh3Content
-        fields = ["content"]
-
-
-class Nh3NullableContent(models.Model):
-    """NH3 test model"""
-
-    CHOICES = (("f", "first choice"), ("s", "second choice"))
-    choice = Nh3Text(choices=CHOICES, blank=True)
-    content = Nh3Text(blank=True, null=True)
-
-
-class Nh3NullableContentModelForm(ModelForm):
-    """NH3 test model form"""
-
-    class Meta:
-        model = Nh3NullableContent
-        fields = ["choice"]
-
-
-class TestNh3ModelField(TestCase):
+class TestNh3TextFieldModelField(TestCase):
     """Test model field"""
 
     def test_cleaning(self):
@@ -57,32 +24,32 @@ class TestNh3ModelField(TestCase):
         }
 
         for key, value in test_data.items():
-            obj = Nh3Content.objects.create(content=value)
+            obj = Nh3TextFieldContent.objects.create(content=value)
             self.assertEqual(obj.content, expected_values[key])
 
     def test_retrieved_values_are_template_safe(self):
-        obj = Nh3Content.objects.create(content="some content")
+        obj = Nh3TextFieldContent.objects.create(content="some content")
         obj.refresh_from_db()
         self.assertIsInstance(obj.content, SafeString)
-        obj = Nh3Content.objects.create(content="")
+        obj = Nh3TextFieldContent.objects.create(content="")
         obj.refresh_from_db()
         self.assertIsInstance(obj.content, SafeString)
 
     def test_saved_values_are_template_safe(self):
-        obj = Nh3Content(content="some content")
+        obj = Nh3TextFieldContent(content="some content")
         obj.save()
         self.assertIsInstance(obj.content, SafeString)
-        obj = Nh3Content(content="")
+        obj = Nh3TextFieldContent(content="")
         obj.save()
         self.assertIsInstance(obj.content, SafeString)
 
     def test_saved_none_values_are_none(self):
-        obj = Nh3Content(null_field=None)
+        obj = Nh3TextFieldContent(null_field=None)
         obj.save()
         self.assertIsNone(obj.null_field)
 
 
-class TestNh3NullableModelField(TestCase):
+class TestNh3TextFieldNullableModelField(TestCase):
     """Test model field"""
 
     def test_cleaning(self):
@@ -101,11 +68,11 @@ class TestNh3NullableModelField(TestCase):
         }
 
         for key, value in test_data.items():
-            obj = Nh3NullableContent.objects.create(content=value)
+            obj = Nh3TextFieldNullableContent.objects.create(content=value)
             self.assertEqual(obj.content, expected_values[key])
 
 
-class TestNh3ModelFormField(TestCase):
+class TestNh3TextFieldModelFormField(TestCase):
     """Test model form field"""
 
     def test_cleaning(self):
@@ -122,7 +89,7 @@ class TestNh3ModelFormField(TestCase):
         }
 
         for key, value in test_data.items():
-            form = Nh3ContentModelForm(data={"content": value})
+            form = Nh3TextFieldContentModelForm(data={"content": value})
             self.assertTrue(form.is_valid())
             obj = form.save()
             self.assertEqual(obj.content, expected_values[key])
@@ -131,17 +98,17 @@ class TestNh3ModelFormField(TestCase):
         """Content field strips comments so ensure they aren't allowed"""
 
         self.assertFalse(
-            Nh3ContentModelForm(
+            Nh3TextFieldContentModelForm(
                 data={"content": "<!-- this is a comment -->"}
             ).is_valid()
         )
 
     def test_field_choices(self):
         """Content field strips comments so ensure they aren't allowed"""
-        test_data = dict(Nh3NullableContent.CHOICES)
+        test_data = dict(Nh3TextFieldNullableContent.CHOICES)
 
         for key, value in test_data.items():
-            form = Nh3NullableContentModelForm(data={"choice": key})
+            form = Nh3TextFieldNullableContentModelForm(data={"choice": key})
             self.assertTrue(form.is_valid())
             obj = form.save()
             self.assertEqual(obj.get_choice_display(), value)


### PR DESCRIPTION
I added on to #44, incorporating the feedback from that PR.

Additionally, since `Nh3CharField` and `Nh3TextField` ended up looking so similar, I just moved their logic into a mixin and tweaked their inheritance. This should also help anybody who is trying to write a custom field with Nh3, since they can now base theirs on `Nh3FieldMixin`.

Tests got a lot more complicated, and they would not allow two different models in different test modules (`test_models_charfield.py` and `test_models_textfield.py`) to be called the same thing. To ensure this wouldn't happen again I moved the test models and forms into their own respective modules.

Closes #44.