### PR TITLE
Fallback to configured project settings when left unspecified on model and form fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# PyCharm
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -127,6 +127,3 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
-
-# PyCharm
-.idea/

--- a/src/django_nh3/forms.py
+++ b/src/django_nh3/forms.py
@@ -7,7 +7,7 @@ import nh3
 from django import forms
 from django.utils.safestring import mark_safe
 
-from src.django_nh3.utils import get_nh3_update_options
+from src.django_nh3.utils import get_nh3_options
 
 
 class Nh3Field(forms.CharField):
@@ -30,7 +30,7 @@ class Nh3Field(forms.CharField):
         super().__init__(*args, **kwargs)
 
         self.empty_value = empty_value
-        self.nh3_options = get_nh3_update_options(
+        self.nh3_options = get_nh3_options(
             tags=tags,
             clean_content_tags=clean_content_tags,
             attributes=attributes,

--- a/src/django_nh3/forms.py
+++ b/src/django_nh3/forms.py
@@ -17,13 +17,13 @@ class Nh3Field(forms.CharField):
 
     def __init__(
         self,
+        tags: set[str] | None = None,
+        clean_content_tags: set[str] | None = None,
         attributes: dict[str, set[str]] | None = None,
         attribute_filter: Callable[[str, str, str], str] | None = None,
-        clean_content_tags: set[str] | None = None,
         empty_value: Any | None = None,
-        link_rel: str = "",
         strip_comments: bool = False,
-        tags: set[str] | None = None,
+        link_rel: str = "",
         *args: Any,
         **kwargs: dict[Any, Any],
     ):
@@ -31,12 +31,12 @@ class Nh3Field(forms.CharField):
 
         self.empty_value = empty_value
         self.nh3_options = get_nh3_update_options(
+            tags=tags,
+            clean_content_tags=clean_content_tags,
             attributes=attributes,
             attribute_filter=attribute_filter,
-            clean_content_tags=clean_content_tags,
-            link_rel=link_rel,
             strip_comments=strip_comments,
-            tags=tags,
+            link_rel=link_rel,
         )
 
     def to_python(self, value: Any) -> Any:

--- a/src/django_nh3/forms.py
+++ b/src/django_nh3/forms.py
@@ -7,7 +7,7 @@ import nh3
 from django import forms
 from django.utils.safestring import mark_safe
 
-from src.django_nh3.utils import get_nh3_options
+from .utils import get_nh3_options
 
 
 class Nh3Field(forms.CharField):

--- a/src/django_nh3/forms.py
+++ b/src/django_nh3/forms.py
@@ -17,33 +17,33 @@ class Nh3Field(forms.CharField):
 
     def __init__(
         self,
-        tags: set[str] | None = None,
-        clean_content_tags: set[str] | None = None,
+        *args: Any,
         attributes: dict[str, set[str]] | None = None,
         attribute_filter: Callable[[str, str, str], str] | None = None,
-        strip_comments: bool = False,
-        link_rel: str = "",
-        generic_attribute_prefixes: set[str] | None = None,
-        tag_attribute_values: dict[str, dict[str, set[str]]] | None = None,
-        set_tag_attribute_values: dict[str, dict[str, str]] | None = None,
-        url_schemes: set[str] | None = None,
+        clean_content_tags: set[str] | None = None,
         empty_value: Any | None = None,
-        *args: Any,
+        generic_attribute_prefixes: set[str] | None = None,
+        link_rel: str = "",
+        set_tag_attribute_values: dict[str, dict[str, str]] | None = None,
+        strip_comments: bool = False,
+        tags: set[str] | None = None,
+        tag_attribute_values: dict[str, dict[str, set[str]]] | None = None,
+        url_schemes: set[str] | None = None,
         **kwargs: dict[Any, Any],
     ):
         super().__init__(*args, **kwargs)
 
         self.empty_value = empty_value
         self.nh3_options = get_nh3_options(
-            tags=tags,
-            clean_content_tags=clean_content_tags,
             attributes=attributes,
             attribute_filter=attribute_filter,
-            strip_comments=strip_comments,
-            link_rel=link_rel,
+            clean_content_tags=clean_content_tags,
             generic_attribute_prefixes=generic_attribute_prefixes,
-            tag_attribute_values=tag_attribute_values,
+            link_rel=link_rel,
             set_tag_attribute_values=set_tag_attribute_values,
+            strip_comments=strip_comments,
+            tags=tags,
+            tag_attribute_values=tag_attribute_values,
             url_schemes=url_schemes,
         )
 

--- a/src/django_nh3/forms.py
+++ b/src/django_nh3/forms.py
@@ -7,6 +7,8 @@ import nh3
 from django import forms
 from django.utils.safestring import mark_safe
 
+from src.django_nh3.utils import get_nh3_update_options
+
 
 class Nh3Field(forms.CharField):
     """nh3 form field"""
@@ -15,27 +17,27 @@ class Nh3Field(forms.CharField):
 
     def __init__(
         self,
-        attributes: dict[str, set[str]] = {},
+        attributes: dict[str, set[str]] | None = None,
         attribute_filter: Callable[[str, str, str], str] | None = None,
-        clean_content_tags: set[str] = set(),
-        empty_value: Any | None = "",
+        clean_content_tags: set[str] | None = None,
+        empty_value: Any | None = None,
         link_rel: str = "",
         strip_comments: bool = False,
-        tags: set[str] = set(),
+        tags: set[str] | None = None,
         *args: Any,
         **kwargs: dict[Any, Any],
     ):
         super().__init__(*args, **kwargs)
 
         self.empty_value = empty_value
-        self.nh3_options = {
-            "attributes": attributes,
-            "attribute_filter": attribute_filter,
-            "clean_content_tags": clean_content_tags,
-            "link_rel": link_rel,
-            "strip_comments": strip_comments,
-            "tags": tags,
-        }
+        self.nh3_options = get_nh3_update_options(
+            attributes=attributes,
+            attribute_filter=attribute_filter,
+            clean_content_tags=clean_content_tags,
+            link_rel=link_rel,
+            strip_comments=strip_comments,
+            tags=tags,
+        )
 
     def to_python(self, value: Any) -> Any:
         """

--- a/src/django_nh3/forms.py
+++ b/src/django_nh3/forms.py
@@ -21,9 +21,13 @@ class Nh3Field(forms.CharField):
         clean_content_tags: set[str] | None = None,
         attributes: dict[str, set[str]] | None = None,
         attribute_filter: Callable[[str, str, str], str] | None = None,
-        empty_value: Any | None = None,
         strip_comments: bool = False,
         link_rel: str = "",
+        generic_attribute_prefixes: set[str] | None = None,
+        tag_attribute_values: dict[str, dict[str, set[str]]] | None = None,
+        set_tag_attribute_values: dict[str, dict[str, str]] | None = None,
+        url_schemes: set[str] | None = None,
+        empty_value: Any | None = None,
         *args: Any,
         **kwargs: dict[Any, Any],
     ):
@@ -37,6 +41,10 @@ class Nh3Field(forms.CharField):
             attribute_filter=attribute_filter,
             strip_comments=strip_comments,
             link_rel=link_rel,
+            generic_attribute_prefixes=generic_attribute_prefixes,
+            tag_attribute_values=tag_attribute_values,
+            set_tag_attribute_values=set_tag_attribute_values,
+            url_schemes=url_schemes,
         )
 
     def to_python(self, value: Any) -> Any:

--- a/src/django_nh3/models.py
+++ b/src/django_nh3/models.py
@@ -11,30 +11,31 @@ from django.forms import Field as FormField
 from django.utils.safestring import mark_safe
 
 from . import forms
+from .utils import get_nh3_update_options
 
 
 class Nh3Field(models.TextField):
     def __init__(
         self,
-        attributes: dict[str, set[str]] = {},
+        attributes: dict[str, set[str]] | None = None,
         attribute_filter: Callable[[str, str, str], str] | None = None,
-        clean_content_tags: set[str] = set(),
+        clean_content_tags: set[str] | None = None,
         link_rel: str = "",
         strip_comments: bool = False,
-        tags: set[str] = set(),
+        tags: set[str] | None = None,
         *args: Any,
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
 
-        self.nh3_options = {
-            "attributes": attributes,
-            "attribute_filter": attribute_filter,
-            "clean_content_tags": clean_content_tags,
-            "link_rel": link_rel,
-            "strip_comments": strip_comments,
-            "tags": tags,
-        }
+        self.nh3_options = get_nh3_update_options(
+            attributes=attributes,
+            attribute_filter=attribute_filter,
+            clean_content_tags=clean_content_tags,
+            link_rel=link_rel,
+            strip_comments=strip_comments,
+            tags=tags,
+        )
 
     def formfield(
         self, form_class: FormField = forms.Nh3Field, **kwargs: Any

--- a/src/django_nh3/models.py
+++ b/src/django_nh3/models.py
@@ -17,31 +17,31 @@ from .utils import get_nh3_options
 class Nh3Field(models.TextField):
     def __init__(
         self,
-        tags: set[str] | None = None,
-        clean_content_tags: set[str] | None = None,
+        *args: Any,
         attributes: dict[str, set[str]] | None = None,
         attribute_filter: Callable[[str, str, str], str] | None = None,
-        strip_comments: bool = False,
-        link_rel: str = "",
+        clean_content_tags: set[str] | None = None,
         generic_attribute_prefixes: set[str] | None = None,
-        tag_attribute_values: dict[str, dict[str, set[str]]] | None = None,
+        link_rel: str = "",
         set_tag_attribute_values: dict[str, dict[str, str]] | None = None,
+        strip_comments: bool = False,
+        tags: set[str] | None = None,
+        tag_attribute_values: dict[str, dict[str, set[str]]] | None = None,
         url_schemes: set[str] | None = None,
-        *args: Any,
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
 
         self.nh3_options = get_nh3_options(
-            tags=tags,
-            clean_content_tags=clean_content_tags,
             attributes=attributes,
             attribute_filter=attribute_filter,
-            strip_comments=strip_comments,
-            link_rel=link_rel,
+            clean_content_tags=clean_content_tags,
             generic_attribute_prefixes=generic_attribute_prefixes,
-            tag_attribute_values=tag_attribute_values,
+            link_rel=link_rel,
             set_tag_attribute_values=set_tag_attribute_values,
+            strip_comments=strip_comments,
+            tags=tags,
+            tag_attribute_values=tag_attribute_values,
             url_schemes=url_schemes,
         )
 

--- a/src/django_nh3/models.py
+++ b/src/django_nh3/models.py
@@ -11,7 +11,7 @@ from django.forms import Field as FormField
 from django.utils.safestring import mark_safe
 
 from . import forms
-from .utils import get_nh3_update_options
+from .utils import get_nh3_options
 
 
 class Nh3Field(models.TextField):
@@ -28,7 +28,7 @@ class Nh3Field(models.TextField):
     ) -> None:
         super().__init__(*args, **kwargs)
 
-        self.nh3_options = get_nh3_update_options(
+        self.nh3_options = get_nh3_options(
             tags=tags,
             clean_content_tags=clean_content_tags,
             attributes=attributes,

--- a/src/django_nh3/models.py
+++ b/src/django_nh3/models.py
@@ -17,24 +17,24 @@ from .utils import get_nh3_update_options
 class Nh3Field(models.TextField):
     def __init__(
         self,
+        tags: set[str] | None = None,
+        clean_content_tags: set[str] | None = None,
         attributes: dict[str, set[str]] | None = None,
         attribute_filter: Callable[[str, str, str], str] | None = None,
-        clean_content_tags: set[str] | None = None,
-        link_rel: str = "",
         strip_comments: bool = False,
-        tags: set[str] | None = None,
+        link_rel: str = "",
         *args: Any,
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
 
         self.nh3_options = get_nh3_update_options(
+            tags=tags,
+            clean_content_tags=clean_content_tags,
             attributes=attributes,
             attribute_filter=attribute_filter,
-            clean_content_tags=clean_content_tags,
-            link_rel=link_rel,
             strip_comments=strip_comments,
-            tags=tags,
+            link_rel=link_rel,
         )
 
     def formfield(
@@ -47,12 +47,12 @@ class Nh3Field(models.TextField):
             kwargs.update(
                 {
                     "max_length": self.max_length,
+                    "tags": self.nh3_options.get("tags"),
+                    "clean_content_tags": self.nh3_options.get("clean_content_tags"),
                     "attributes": self.nh3_options.get("attributes"),
                     "attribute_filter": self.nh3_options.get("attribute_filter"),
-                    "clean_content_tags": self.nh3_options.get("clean_content_tags"),
-                    "link_rel": self.nh3_options.get("link_rel"),
                     "strip_comments": self.nh3_options.get("strip_comments"),
-                    "tags": self.nh3_options.get("tags"),
+                    "link_rel": self.nh3_options.get("link_rel"),
                     "required": not self.blank,
                 }
             )

--- a/src/django_nh3/models.py
+++ b/src/django_nh3/models.py
@@ -23,6 +23,10 @@ class Nh3Field(models.TextField):
         attribute_filter: Callable[[str, str, str], str] | None = None,
         strip_comments: bool = False,
         link_rel: str = "",
+        generic_attribute_prefixes: set[str] | None = None,
+        tag_attribute_values: dict[str, dict[str, set[str]]] | None = None,
+        set_tag_attribute_values: dict[str, dict[str, str]] | None = None,
+        url_schemes: set[str] | None = None,
         *args: Any,
         **kwargs: Any,
     ) -> None:
@@ -35,6 +39,10 @@ class Nh3Field(models.TextField):
             attribute_filter=attribute_filter,
             strip_comments=strip_comments,
             link_rel=link_rel,
+            generic_attribute_prefixes=generic_attribute_prefixes,
+            tag_attribute_values=tag_attribute_values,
+            set_tag_attribute_values=set_tag_attribute_values,
+            url_schemes=url_schemes,
         )
 
     def formfield(
@@ -53,6 +61,16 @@ class Nh3Field(models.TextField):
                     "attribute_filter": self.nh3_options.get("attribute_filter"),
                     "strip_comments": self.nh3_options.get("strip_comments"),
                     "link_rel": self.nh3_options.get("link_rel"),
+                    "generic_attribute_prefixes": self.nh3_options.get(
+                        "generic_attribute_prefixes"
+                    ),
+                    "tag_attribute_values": self.nh3_options.get(
+                        "tag_attribute_values"
+                    ),
+                    "set_tag_attribute_values": self.nh3_options.get(
+                        "set_tag_attribute_values"
+                    ),
+                    "url_schemes": self.nh3_options.get("url_schemes"),
                     "required": not self.blank,
                 }
             )

--- a/src/django_nh3/utils.py
+++ b/src/django_nh3/utils.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Callable
 from typing import Any
 
 from django.conf import settings
@@ -46,5 +47,36 @@ def get_nh3_default_options() -> dict[str, Any]:
                 attr = copy_dict
 
             nh3_args[kwarg] = attr
+
+    return nh3_args
+
+
+def get_nh3_update_options(
+    attributes: dict[str, set[str]] | None = None,
+    attribute_filter: Callable[[str, str, str], str] | None = None,
+    clean_content_tags: set[str] | None = None,
+    link_rel: str = "",
+    strip_comments: bool = False,
+    tags: set[str] | None = None,
+) -> dict[str, Any]:
+    _attributes = attributes or getattr(settings, "NH3_ALLOWED_ATTRIBUTES", {})
+    _attribute_filter = attribute_filter or getattr(
+        settings, "NH3_ALLOWED_ATTRIBUTES_FILTER", None
+    )
+    _clean_content_tags = (
+        clean_content_tags or getattr(settings, "NH3_CLEAN_CONTENT_TAGS", None) or set()
+    )
+    _link_rel = link_rel or getattr(settings, "NH3_CLEAN_CONTENT_TAGS", "")
+    _strip_comments = strip_comments or getattr(settings, "NH3_STRIP_COMMENTS", False)
+    _tags = tags or getattr(settings, "NH3_ALLOWED_TAGS", None) or set()
+
+    nh3_args = {
+        "attributes": {tag: set(attributes) for tag, attributes in _attributes.items()},
+        "attribute_filter": _attribute_filter,
+        "clean_content_tags": set(_clean_content_tags),
+        "link_rel": _link_rel,
+        "strip_comments": _strip_comments,
+        "tags": set(_tags),
+    }
 
     return nh3_args

--- a/src/django_nh3/utils.py
+++ b/src/django_nh3/utils.py
@@ -54,32 +54,32 @@ def get_nh3_default_options() -> dict[str, Any]:
     return nh3_args
 
 
-def get_nh3_update_options(
+def get_nh3_options(
+    tags: set[str] | None = None,
+    clean_content_tags: set[str] | None = None,
     attributes: dict[str, set[str]] | None = None,
     attribute_filter: Callable[[str, str, str], str] | None = None,
-    clean_content_tags: set[str] | None = None,
-    link_rel: str = "",
     strip_comments: bool = False,
-    tags: set[str] | None = None,
+    link_rel: str = "",
 ) -> dict[str, Any]:
+    _tags = tags or getattr(settings, "NH3_ALLOWED_TAGS", None) or set()
+    _clean_content_tags = (
+        clean_content_tags or getattr(settings, "NH3_CLEAN_CONTENT_TAGS", None) or set()
+    )
     _attributes = attributes or getattr(settings, "NH3_ALLOWED_ATTRIBUTES", {})
     _attribute_filter = attribute_filter or getattr(
         settings, "NH3_ALLOWED_ATTRIBUTES_FILTER", None
     )
-    _clean_content_tags = (
-        clean_content_tags or getattr(settings, "NH3_CLEAN_CONTENT_TAGS", None) or set()
-    )
-    _link_rel = link_rel or getattr(settings, "NH3_LINK_REL", "")
     _strip_comments = strip_comments or getattr(settings, "NH3_STRIP_COMMENTS", False)
-    _tags = tags or getattr(settings, "NH3_ALLOWED_TAGS", None) or set()
+    _link_rel = link_rel or getattr(settings, "NH3_LINK_REL", "")
 
     nh3_args = {
+        "tags": set(_tags),
+        "clean_content_tags": set(_clean_content_tags),
         "attributes": {tag: set(attributes) for tag, attributes in _attributes.items()},
         "attribute_filter": _attribute_filter,
-        "clean_content_tags": set(_clean_content_tags),
-        "link_rel": _link_rel,
         "strip_comments": _strip_comments,
-        "tags": set(_tags),
+        "link_rel": _link_rel,
     }
 
     return nh3_args

--- a/src/django_nh3/utils.py
+++ b/src/django_nh3/utils.py
@@ -29,8 +29,11 @@ def get_nh3_default_options() -> dict[str, Any]:
 
     nh3_settings = {
         "NH3_ALLOWED_TAGS": "tags",
+        "NH3_CLEAN_CONTENT_TAGS": "clean_content_tags",
         "NH3_ALLOWED_ATTRIBUTES": "attributes",
+        "NH3_ALLOWED_ATTRIBUTES_FILTER": "attribute_filter",
         "NH3_STRIP_COMMENTS": "strip_comments",
+        "NH3_LINK_REL": "link_rel",
     }
 
     for setting, kwarg in nh3_settings.items():

--- a/src/django_nh3/utils.py
+++ b/src/django_nh3/utils.py
@@ -66,7 +66,7 @@ def get_nh3_update_options(
     _clean_content_tags = (
         clean_content_tags or getattr(settings, "NH3_CLEAN_CONTENT_TAGS", None) or set()
     )
-    _link_rel = link_rel or getattr(settings, "NH3_CLEAN_CONTENT_TAGS", "")
+    _link_rel = link_rel or getattr(settings, "NH3_LINK_REL", "")
     _strip_comments = strip_comments or getattr(settings, "NH3_STRIP_COMMENTS", False)
     _tags = tags or getattr(settings, "NH3_ALLOWED_TAGS", None) or set()
 

--- a/src/django_nh3/utils.py
+++ b/src/django_nh3/utils.py
@@ -3,6 +3,7 @@ from collections.abc import Callable
 from typing import Any
 
 from django.conf import settings
+from django.utils.module_loading import import_string
 
 logger = logging.getLogger(__name__)
 
@@ -17,39 +18,114 @@ def get_nh3_default_options() -> dict[str, Any]:
         BLEACH_ALLOWED_TAGS         -> NH3_ALLOWED_TAGS
         BLEACH_ALLOWED_ATTRIBUTES   -> NH3_ALLOWED_ATTRIBUTES
         BLEACH_STRIP_COMMENTS       -> NH3_STRIP_COMMENTS
+        BLEACH_ALLOWED_PROTOCOLS    -> NH3_ALLOWED_URL_SCHEMES
 
     While other settings have no current support in nh3:
 
         BLEACH_ALLOWED_STYLES       -> There is no support for styling
-        BLEACH_ALLOWED_PROTOCOLS    -> There is no support for protocols
         BLEACH_STRIP_TAGS           -> This is the default behavior of nh3
 
     """
     nh3_args: dict[str, Any] = {}
 
     nh3_settings = {
+        # Sets the tags that are allowed (eg: allowlist)
+        # Ensure that no tags in this are also in NH3_CLEAN_CONTENT_TAGS or
+        # NH3_ALLOWED_ATTRIBUTES
         "NH3_ALLOWED_TAGS": "tags",
-        "NH3_CLEAN_CONTENT_TAGS": "clean_content_tags",
+        # Sets the tags whose contents will be completely removed from the
+        # output (eg: blocklist)
+        # Ensure that no tags in this are also in NH3_ALLOWED_TAGS or
+        # NH3_ALLOWED_ATTRIBUTES
+        # Default: script, style
         "NH3_ALLOWED_ATTRIBUTES": "attributes",
+        # Sets the HTML attributes that are allowed on specific tags, * key
+        # means the attributes are allowed on any tag (eg: allowlist)
+        # Ensure that no tags in this are also in NH3_CLEAN_CONTENT_TAGS
+        "NH3_CLEAN_CONTENT_TAGS": "clean_content_tags",
+        # Dotted path to a callback that allows rewriting of all attributes.
+        # The callback takes name of the element, attribute and its value.
+        # Returns None to remove the attribute, or a value to use
         "NH3_ALLOWED_ATTRIBUTES_FILTER": "attribute_filter",
+        # Configures the handling of HTML comments, defaults to True
         "NH3_STRIP_COMMENTS": "strip_comments",
+        # Configures a rel attribute that will be added on links, defaults to
+        # noopener noreferrer. To turn on rel-insertion, pass a space-separated
+        # list. If rel is in the generic or tag attributes, this must be set to
+        # None
+        # Common rel values to include:
+        # noopener
+        # noreferrer
+        # nofollow
         "NH3_LINK_REL": "link_rel",
+        # Sets the prefix of attributes that are allowed on any tag
+        "NH3_ALLOWED_GENERIC_ATTRIBUTE_PREFIXES": "generic_attribute_prefixes",
+        # Sets the values of HTML attributes that are allowed on specific tags.
+        # The value is structured as a map from tag names to a map from
+        # attribute names to a set of attribute values. If a tag is not itself
+        # whitelisted, adding entries to this map will do nothing.
+        "NH3_ALLOWED_TAG_ATTRIBUTE_VALUES": "tag_attribute_values",
+        # Sets the values of HTML attributes that are to be set on specific
+        # tags. The value is structured as a map from tag names to a map from
+        # attribute names to an attribute value. If a tag is not itself
+        # whitelisted, adding entries to this map will do nothing.
+        "NH3_SET_TAG_ATTRIBUTE_VALUES": "set_tag_attribute_values",
+        # Sets the URL schemes permitted on href and src attributes
+        "NH3_ALLOWED_URL_SCHEMES": "url_schemes",
     }
 
-    for setting, kwarg in nh3_settings.items():
-        if hasattr(settings, setting):
-            attr = getattr(settings, setting)
+    for setting_name, kwarg in nh3_settings.items():
+        if hasattr(settings, setting_name):
+            setting_value = getattr(settings, setting_name)
 
             # Convert from general iterables to sets
-            if setting == "NH3_ALLOWED_TAGS":
-                attr = set(attr)
-            elif setting == "NH3_ALLOWED_ATTRIBUTES":
-                copy_dict = attr.copy()
-                for tag, attributes in attr.items():
-                    copy_dict[tag] = set(attributes)
-                attr = copy_dict
+            if setting_name in [
+                "NH3_ALLOWED_TAGS",
+                "NH3_CLEAN_CONTENT_TAGS",
+                "NH3_ALLOWED_GENERIC_ATTRIBUTE_PREFIXES",
+                "NH3_ALLOWED_URL_SCHEMES",
+            ]:
+                setting_value = set(setting_value)
 
-            nh3_args[kwarg] = attr
+            elif setting_name == "NH3_ALLOWED_ATTRIBUTES":
+                copy_dict = setting_value.copy()
+                for tag, attributes in setting_value.items():
+                    copy_dict[tag] = set(attributes)
+                setting_value = copy_dict
+
+            elif setting_name == "NH3_ALLOWED_ATTRIBUTES_FILTER":
+                if callable(setting_value):
+                    pass
+                elif isinstance(setting_value, str):
+                    setting_value = import_string(setting_value)
+
+            elif setting_name == "NH3_STRIP_COMMENTS":
+                setting_value = bool(setting_value)
+
+            elif setting_name == "NH3_LINK_REL":
+                setting_value = str(setting_value)
+
+            elif setting_name == "NH3_ALLOWED_TAG_ATTRIBUTE_VALUES":
+                # The value is structured as a map from tag names to a map from
+                # attribute names to a set of attribute values.
+                allowed_tag_attr_dict: dict[str, dict[str, set[str]]] = {}
+                for tag_name, attribute_dict in setting_value.items():
+                    allowed_tag_attr_dict[tag_name] = {}
+                    for attr_name, attr_value in attribute_dict.items():
+                        allowed_tag_attr_dict[tag_name][attr_name] = set(attr_value)
+                setting_value = allowed_tag_attr_dict
+
+            elif setting_name == "NH3_SET_TAG_ATTRIBUTE_VALUES":
+                # The value is structured as a map from tag names to a map from
+                # attribute names to an attribute value.
+                set_tag_attr_dict: dict[str, dict[str, str]] = {}
+                for tag_name, attribute_dict in setting_value.items():
+                    set_tag_attr_dict[tag_name] = {}
+                    for attr_name, attr_value in attribute_dict.items():
+                        set_tag_attr_dict[tag_name][attr_name] = str(attr_value)
+                setting_value = set_tag_attr_dict
+
+            nh3_args[kwarg] = setting_value
 
     return nh3_args
 
@@ -61,17 +137,37 @@ def get_nh3_options(
     attribute_filter: Callable[[str, str, str], str] | None = None,
     strip_comments: bool = False,
     link_rel: str = "",
+    generic_attribute_prefixes: set[str] | None = None,
+    tag_attribute_values: dict[str, dict[str, set[str]]] | None = None,
+    set_tag_attribute_values: dict[str, dict[str, str]] | None = None,
+    url_schemes: set[str] | None = None,
 ) -> dict[str, Any]:
     _tags = tags or getattr(settings, "NH3_ALLOWED_TAGS", None) or set()
+    _attributes = attributes or getattr(settings, "NH3_ALLOWED_ATTRIBUTES", {})
     _clean_content_tags = (
         clean_content_tags or getattr(settings, "NH3_CLEAN_CONTENT_TAGS", None) or set()
     )
-    _attributes = attributes or getattr(settings, "NH3_ALLOWED_ATTRIBUTES", {})
     _attribute_filter = attribute_filter or getattr(
         settings, "NH3_ALLOWED_ATTRIBUTES_FILTER", None
     )
     _strip_comments = strip_comments or getattr(settings, "NH3_STRIP_COMMENTS", False)
     _link_rel = link_rel or getattr(settings, "NH3_LINK_REL", "")
+    _generic_attribute_prefixes = (
+        generic_attribute_prefixes
+        or getattr(settings, "NH3_ALLOWED_GENERIC_ATTRIBUTE_PREFIXES", None)
+        or set()
+    )
+    _tag_attribute_values = (
+        tag_attribute_values
+        or getattr(settings, "NH3_ALLOWED_TAG_ATTRIBUTE_VALUES", None)
+        or {}
+    )
+    _set_tag_attribute_values = (
+        set_tag_attribute_values
+        or getattr(settings, "NH3_SET_TAG_ATTRIBUTE_VALUES", None)
+        or {}
+    )
+    _url_schemes = url_schemes or getattr(settings, "", None) or set()
 
     nh3_args = {
         "tags": set(_tags),
@@ -80,6 +176,10 @@ def get_nh3_options(
         "attribute_filter": _attribute_filter,
         "strip_comments": _strip_comments,
         "link_rel": _link_rel,
+        "generic_attribute_prefixes": _generic_attribute_prefixes,
+        "tag_attribute_values": _tag_attribute_values,
+        "set_tag_attribute_values": _set_tag_attribute_values,
+        "url_schemes": _url_schemes,
     }
 
     return nh3_args

--- a/src/django_nh3/utils.py
+++ b/src/django_nh3/utils.py
@@ -155,44 +155,40 @@ def get_nh3_options(
     set_tag_attribute_values: dict[str, dict[str, str]] | None = None,
     url_schemes: set[str] | None = None,
 ) -> dict[str, Any]:
-    _tags = tags or getattr(settings, "NH3_ALLOWED_TAGS", None) or set()
-    _attributes = attributes or getattr(settings, "NH3_ALLOWED_ATTRIBUTES", {})
-    _clean_content_tags = (
-        clean_content_tags or getattr(settings, "NH3_CLEAN_CONTENT_TAGS", None) or set()
+    defaults = get_nh3_configured_default_options()
+
+    tags = tags or defaults.get("tags", None) or set()
+    attributes = attributes or defaults.get("attributes", {})
+    clean_content_tags = (
+        clean_content_tags or defaults.get("clean_content_tags", None) or set()
     )
-    _attribute_filter = attribute_filter or getattr(
-        settings, "NH3_ALLOWED_ATTRIBUTES_FILTER", None
-    )
-    _strip_comments = strip_comments or getattr(settings, "NH3_STRIP_COMMENTS", False)
-    _link_rel = link_rel or getattr(settings, "NH3_LINK_REL", "")
-    _generic_attribute_prefixes = (
+    attribute_filter = attribute_filter or defaults.get("attribute_filter", None)
+    strip_comments = strip_comments or defaults.get("strip_comments", False)
+    link_rel = link_rel or defaults.get("link_rel", "")
+    generic_attribute_prefixes = (
         generic_attribute_prefixes
-        or getattr(settings, "NH3_ALLOWED_GENERIC_ATTRIBUTE_PREFIXES", None)
+        or defaults.get("generic_attribute_prefixes", None)
         or set()
     )
-    _tag_attribute_values = (
-        tag_attribute_values
-        or getattr(settings, "NH3_ALLOWED_TAG_ATTRIBUTE_VALUES", None)
-        or {}
+    tag_attribute_values = (
+        tag_attribute_values or defaults.get("tag_attribute_values", None) or {}
     )
-    _set_tag_attribute_values = (
-        set_tag_attribute_values
-        or getattr(settings, "NH3_SET_TAG_ATTRIBUTE_VALUES", None)
-        or {}
+    set_tag_attribute_values = (
+        set_tag_attribute_values or defaults.get("set_tag_attribute_values", None) or {}
     )
-    _url_schemes = url_schemes or getattr(settings, "", None) or set()
+    url_schemes = url_schemes or defaults.get("url_schemes", None) or set()
 
-    nh3_args = {
-        "tags": set(_tags),
-        "clean_content_tags": set(_clean_content_tags),
-        "attributes": {tag: set(attributes) for tag, attributes in _attributes.items()},
-        "attribute_filter": _attribute_filter,
-        "strip_comments": _strip_comments,
-        "link_rel": _link_rel,
-        "generic_attribute_prefixes": _generic_attribute_prefixes,
-        "tag_attribute_values": _tag_attribute_values,
-        "set_tag_attribute_values": _set_tag_attribute_values,
-        "url_schemes": _url_schemes,
-    }
-
-    return nh3_args
+    return normalize_nh3_options(
+        {
+            "tags": tags,
+            "clean_content_tags": clean_content_tags,
+            "attributes": attributes,
+            "attribute_filter": attribute_filter,
+            "strip_comments": strip_comments,
+            "link_rel": link_rel,
+            "generic_attribute_prefixes": generic_attribute_prefixes,
+            "tag_attribute_values": tag_attribute_values,
+            "set_tag_attribute_values": set_tag_attribute_values,
+            "url_schemes": url_schemes,
+        }
+    )

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 from django.test import TestCase
 
-from django_nh3.utils import get_nh3_default_options
+from django_nh3.utils import get_nh3_default_options, normalize_nh3_options
 
 from .constants import ALLOWED_ATTRIBUTES, ALLOWED_TAGS, STRIP_COMMENTS
 
@@ -31,3 +31,193 @@ class TestBleachOptions(TestCase):
     def test_strip_comments(self, settings):
         nh3_args = get_nh3_default_options()
         self.assertEqual(nh3_args["strip_comments"], STRIP_COMMENTS)
+
+
+def set_test_flag_true():
+    return "set_test_flag_true"
+
+
+class TestNormalizeNh3Options(TestCase):
+    def test_unrecognized_keys_are_passed_through(self):
+        self.assertEqual(normalize_nh3_options({"unknown": None}), {"unknown": None})
+        self.assertEqual(normalize_nh3_options({"unknown": []}), {"unknown": []})
+        self.assertEqual(normalize_nh3_options({"unknown": ()}), {"unknown": ()})
+        self.assertEqual(normalize_nh3_options({"unknown": set()}), {"unknown": set()})
+
+    def test_tags_clean_content_tags_generic_attribute_prefixes_and_url_schemes(self):
+        for kwargs, expected in [
+            (
+                {"tags": ["one", "two", "three"]},
+                {"tags": {"one", "two", "three"}},
+            ),
+            (
+                {"clean_content_tags": ["two", "three", "four"]},
+                {"clean_content_tags": {"two", "three", "four"}},
+            ),
+            (
+                {"generic_attribute_prefixes": ["three", "four", "five"]},
+                {"generic_attribute_prefixes": {"three", "four", "five"}},
+            ),
+            (
+                {"url_schemes": ["four", "five", "six"]},
+                {"url_schemes": {"four", "five", "six"}},
+            ),
+        ]:
+            with self.subTest(kwargs=kwargs, expected=expected):
+                self.assertDictEqual(
+                    normalize_nh3_options(kwargs),
+                    expected,
+                )
+
+    def test_attribute_filter(self):
+        self.assertDictEqual(
+            normalize_nh3_options({"attribute_filter": set_test_flag_true}),
+            {"attribute_filter": set_test_flag_true},
+        )
+
+        # Make sure that the function is exactly what we expect
+        result = normalize_nh3_options({"attribute_filter": set_test_flag_true})
+        self.assertEqual(result["attribute_filter"](), "set_test_flag_true")
+
+        self.assertDictEqual(
+            normalize_nh3_options(
+                {"attribute_filter": "tests.test_settings.set_test_flag_true"}
+            ),
+            {"attribute_filter": set_test_flag_true},
+        )
+
+        # Make sure that the function is exactly what we expect
+        result = normalize_nh3_options({"attribute_filter": set_test_flag_true})
+        self.assertEqual(result["attribute_filter"](), "set_test_flag_true")
+
+    def test_strip_comments(self):
+        for kwargs, expected in [
+            (
+                {"strip_comments": None},
+                {"strip_comments": False},
+            ),
+            (
+                {"strip_comments": []},
+                {"strip_comments": False},
+            ),
+            (
+                {"strip_comments": ""},
+                {"strip_comments": False},
+            ),
+            (
+                {"strip_comments": True},
+                {"strip_comments": True},
+            ),
+            (
+                {"strip_comments": "happy"},
+                {"strip_comments": True},
+            ),
+        ]:
+            with self.subTest(kwargs=kwargs, expected=expected):
+                self.assertDictEqual(
+                    normalize_nh3_options(kwargs),  # type: ignore[arg-type]
+                    expected,
+                )
+
+    def test_link_rel(self):
+        for kwargs, expected in [
+            (
+                {"link_rel": ""},
+                {"link_rel": ""},
+            ),
+            (
+                {"link_rel": "my string"},
+                {"link_rel": "my string"},
+            ),
+            (
+                {"link_rel": 0},
+                {"link_rel": "0"},
+            ),
+            (
+                {"link_rel": None},
+                {"link_rel": "None"},
+            ),
+            (
+                {"link_rel": True},
+                {"link_rel": "True"},
+            ),
+            (
+                {"link_rel": False},
+                {"link_rel": "False"},
+            ),
+        ]:
+            with self.subTest(kwargs=kwargs, expected=expected):
+                self.assertDictEqual(
+                    normalize_nh3_options(kwargs),  # type: ignore[arg-type]
+                    expected,
+                )
+
+    def assertDataStructureEqual(self, left, right):
+        if isinstance(left, set):
+            self.assertIsInstance(right, set)
+            self.assertSetEqual(left, right)
+        elif isinstance(left, dict):
+            self.assertIsInstance(right, dict)
+            self.assertEqual(left.keys(), right.keys())
+            for key in left.keys():
+                self.assertIn(key, right.keys())
+                self.assertDataStructureEqual(left[key], right[key])
+        else:
+            self.assertIsInstance(right, left.__class__)
+            self.assertEqual(left, right)
+
+    def test_tag_attribute_values(self):
+        self.assertDataStructureEqual(
+            normalize_nh3_options(
+                {
+                    "tag_attribute_values": {
+                        "tag1": {
+                            "attrA": ["A1", "A2", "A3"],
+                            "attrB": ("B1", "B2", "B3"),
+                        },
+                        "tag2": {
+                            "attrC": ["C1", "C2", "C3"],
+                        },
+                    },
+                }
+            ),
+            {
+                "tag_attribute_values": {
+                    "tag1": {
+                        "attrA": {"A1", "A2", "A3"},
+                        "attrB": {"B1", "B2", "B3"},
+                    },
+                    "tag2": {
+                        "attrC": {"C1", "C2", "C3"},
+                    },
+                },
+            },
+        )
+
+    def test_set_tag_attribute_values(self):
+        self.assertDataStructureEqual(
+            normalize_nh3_options(
+                {
+                    "set_tag_attribute_values": {
+                        "tag1": {
+                            "attrA": "Avalue",
+                            "attrB": "Bvalue",
+                        },
+                        "tag2": {
+                            "attrC": "Cvalue",
+                        },
+                    },
+                }
+            ),
+            {
+                "set_tag_attribute_values": {
+                    "tag1": {
+                        "attrA": "Avalue",
+                        "attrB": "Bvalue",
+                    },
+                    "tag2": {
+                        "attrC": "Cvalue",
+                    },
+                },
+            },
+        )


### PR DESCRIPTION
This PR builds on top of PR #37 and supersedes it.

This project currently requires users to pass in all NH3 configuration options wherever they use an NH3 model field or form field. Options for model fields and form fields do not follow any project-wide configured settings values.

Instead, pull any unspecified NH3 model field and form field options from the Django project `settings.py` module. Essentially supporting project-wide configuration (via `settings.py`), and per-field configuration. This follows the DRY principle and makes it easier to use Nh3Fields.

I also decomposed a few functions in this package's `utils` module a bit more, which then allowed me to simplify them further.

Closes #37.